### PR TITLE
[refactor] 예약 도메인 로직 추가

### DIFF
--- a/src/main/java/com/hhconcert/server/business/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/hhconcert/server/business/domain/payment/service/PaymentService.java
@@ -26,7 +26,7 @@ public class PaymentService {
     @Transactional
     public PaymentResult payment(PaymentInfo info) {
         Reservation reservation = reservationRepository.findReserve(info.reserveId());
-        if (reservation.getPrice() != info.amount()) {
+        if (reservation.isNotMatchAmount(info.amount())) {
             throw new PaymentException("결제 금액이 일치하지 않습니다.");
         }
 

--- a/src/main/java/com/hhconcert/server/business/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/hhconcert/server/business/domain/reservation/entity/Reservation.java
@@ -73,9 +73,16 @@ public class Reservation extends BaseEntity {
                 .build();
     }
 
+    public boolean isNotMatchAmount(int amount) {
+        return this.price != amount;
+    }
+
     public void updateForComplete() {
         if (this.status != ReservationStatus.TEMP) {
             throw new ReservationException("결제할 수 없는 예약 내역입니다.");
+        }
+        if (this.expiredAt.isBefore(LocalDateTime.now())) {
+            throw new ReservationException("임시 예약 시간이 만료되었습니다.");
         }
         this.status = ReservationStatus.COMPLETE;
         this.expiredAt = null;

--- a/src/test/java/com/hhconcert/server/business/domain/reservation/entity/ReservationTest.java
+++ b/src/test/java/com/hhconcert/server/business/domain/reservation/entity/ReservationTest.java
@@ -1,0 +1,76 @@
+package com.hhconcert.server.business.domain.reservation.entity;
+
+import com.hhconcert.server.business.domain.concert.entity.Concert;
+import com.hhconcert.server.business.domain.schedule.entity.Schedule;
+import com.hhconcert.server.business.domain.seat.entity.Seat;
+import com.hhconcert.server.business.domain.user.entity.User;
+import com.hhconcert.server.global.exception.ReservationException;
+import org.junit.jupiter.api.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReservationTest {
+
+    User user;
+    Concert concert;
+    Schedule schedule;
+    Seat seat;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(1L, "test1234", 80000);
+        concert = new Concert(1L, "콘서트명", LocalDate.now(), LocalDate.now().plusDays(1));
+        schedule = new Schedule(1L, concert, LocalDate.now());
+        seat = new Seat(1L, schedule, "A1", 75000);
+    }
+
+    @DisplayName("임시 예약 내역이 생성된다.")
+    @Test
+    void createTempReserve() {
+        Reservation temp = Reservation.createTemp(user, concert, schedule, seat);
+
+        assertThat(temp.getPrice()).isEqualTo(75000);
+        assertThat(temp.getStatus()).isEqualTo(ReservationStatus.TEMP);
+        assertThat(temp.getExpiredAt()).isNotNull().isAfter(LocalDateTime.now());
+    }
+
+    @DisplayName("결제 금액이 일치하지 않는 경우 true를 반환한다.")
+    @Test
+    void paymentAMountIsNotMatchPrice_thenTrue() {
+        int invalidAmount = 70000;
+
+        Reservation temp = Reservation.createTemp(user, concert, schedule, seat);
+
+        boolean result = temp.isNotMatchAmount(invalidAmount);
+
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("최종 예약 상태로 변경 시 조건에 따라 예외가 발생한다.")
+    @TestFactory
+    Collection<DynamicTest> updateForCompleteTests() {
+        return List.of(
+            DynamicTest.dynamicTest("예약 상태가 TEMP가 아닌 경우, 예약건을 결제할 수 없다.", () -> {
+                Reservation reservation = new Reservation(user, concert, schedule, seat, 75000, ReservationStatus.CANCEL, null);
+
+                assertThatThrownBy(reservation::updateForComplete)
+                        .isInstanceOf(ReservationException.class)
+                        .hasMessage("결제할 수 없는 예약 내역입니다.");
+            }),
+            DynamicTest.dynamicTest("임시 예약 만료 시간이 지난 경우, 예약건을 결제할 수 없다.", () -> {
+                Reservation reservation = new Reservation(user, concert, schedule, seat, 75000, ReservationStatus.TEMP, LocalDateTime.now().minusMinutes(1));
+
+                assertThatThrownBy(reservation::updateForComplete)
+                        .isInstanceOf(ReservationException.class)
+                        .hasMessage("임시 예약 시간이 만료되었습니다.");
+            })
+        );
+    }
+
+}


### PR DESCRIPTION
### 결제 금액 일치 여부
- reservation에서 값을 꺼내지 않고 요청하는 방식으로 변경

### 최종 예약 상태 변경 검증 조건 추가
- 임시 예약 만료 검증
